### PR TITLE
カード表示箇所をコンポーネント化して管理

### DIFF
--- a/src/components/adminParts/mainCard.tsx
+++ b/src/components/adminParts/mainCard.tsx
@@ -1,0 +1,127 @@
+import { Box, Button, CardBody, Image, Input, Text, Textarea } from '@chakra-ui/react';
+import { ChangeEvent, useContext, useRef, useState } from 'react';
+
+import { MainCardContext } from '../../page/admin';
+import MonthSelect from '../adminParts/months';
+import { StarIcon } from '@chakra-ui/icons';
+
+/**
+ * メインカードコンポーネント
+ * @returns {JSX.Element} メインカードコンポーネント
+ */
+export default function MainCard() {
+  const { imageFile, date, description, handleImageDelete, setImageFile, setDate, setDescription, setMainImageFlg } =
+    useContext(MainCardContext);
+
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const [rating, setRating] = useState<number>(1);
+
+  /**
+   * スター評価がクリックされた時に実行されるハンドラー
+   * @param {number} index - クリックされたスターのインデックス
+   */
+  const handleStarClick = (index: number) => {
+    setRating(index);
+    // サーバーに送信する処理を追加予定
+  };
+
+  /**
+   * ファイルを選択するダイアログを開く
+   */
+  const fileUpload = () => {
+    if (inputRef.current) {
+      inputRef.current.click();
+    }
+  };
+
+  /**
+   * 画像の選択時に実行されるハンドラー
+   * @param {ChangeEvent<HTMLInputElement>} target - input要素の変更イベント
+   */
+  const handleImageChange = ({ target }: ChangeEvent<HTMLInputElement>) => {
+    const { files } = target; // target オブジェクトからファイルの情報を取得
+    if (files) {
+      const newFile = Array.from(files);
+      setImageFile((prevImageFile) => [...prevImageFile, ...newFile]); // 新たに選択されたファイルを既存の画像ファイル配列に追加
+      setMainImageFlg(true);
+    }
+  };
+
+  /**
+   * 画像説明の変更ハンドラー
+   * @param {string} descriptions - 画像の説明
+   */
+  const handleDescriptionChange = (text: string) => {};
+
+  /**
+   * 日付の変更ハンドラー
+   * @param {string} dates - 新しい日付情報
+   */
+  const handleDateChange = (dates: string) => {};
+
+  return (
+    <CardBody>
+      <Box display='flex' mb='3'>
+        <Text fontWeight='bold'>メイン画像:&ensp;</Text>
+        {imageFile[0] ? (
+          <Button colorScheme='orange' size='xs' onClick={handleImageDelete}>
+            画像を削除
+          </Button>
+        ) : (
+          <>
+            <Button type='submit' colorScheme='teal' size='xs' onClick={fileUpload}>
+              画像を選択
+            </Button>
+            <Input type='file' display='none' ref={inputRef} onChange={handleImageChange} />
+          </>
+        )}
+      </Box>
+      <Box>
+        <Box display={{ md: 'flex' }} mb='3'>
+          <Text fontWeight='bold'>ファイル名:&ensp;</Text>
+          <Text>{imageFile.length > 0 ? imageFile[0].name : '未選択'}</Text>
+        </Box>
+        <Box display={{ md: 'flex' }} mb='3' alignItems='center'>
+          <Text fontWeight='bold'>評価:&ensp;</Text>
+          <Box display='flex'>
+            {Array(5)
+              .fill('')
+              .map((_, i) => (
+                <StarIcon
+                  key={i}
+                  boxSize={5}
+                  mr='0.5'
+                  color={i < rating ? 'yellow.500' : 'gray.400'}
+                  onClick={() => handleStarClick(i + 1)}
+                  style={{ cursor: 'pointer' }}
+                />
+              ))}
+          </Box>
+        </Box>
+        <Box display={{ md: 'flex' }} alignItems='center' mb='3'>
+          <Text fontWeight='bold'>日付:&ensp;</Text>
+          <Box display='flex' alignItems='center'>
+            <MonthSelect selectedMonth={date[0] || '1'} onChange={(selectedMonth) => handleDateChange(selectedMonth)} />
+            <Text px='2'>~</Text>
+            <MonthSelect selectedMonth={date[1] || '2'} onChange={(selectedMonth) => handleDateChange(selectedMonth)} />
+          </Box>
+        </Box>
+        {imageFile[0] && (
+          <Box mb='3'>
+            <Image src={URL.createObjectURL(imageFile[0])} alt={`plant/${String(imageFile[0].name)}`} w='400px' />
+          </Box>
+        )}
+        <Text fontWeight='bold'>画像説明:</Text>
+        <Textarea
+          placeholder='画像の説明を入力'
+          value={description[0] || ''}
+          onChange={(event) => handleDescriptionChange(event.target.value)}
+          borderColor='gray.600'
+          borderRadius='md'
+          px={3}
+          py={2}
+        />
+      </Box>
+    </CardBody>
+  );
+}

--- a/src/components/adminParts/subCard.tsx
+++ b/src/components/adminParts/subCard.tsx
@@ -1,0 +1,52 @@
+import { Box, CardBody, Image, Text, Textarea } from '@chakra-ui/react';
+import { ChangeEvent, useContext, useRef } from 'react';
+
+import { SubCardContext } from '../../page/admin';
+
+interface Props {
+  index: number;
+  item: File;
+}
+/**
+ * サブカードコンポーネント
+ * @returns {JSX.Element} サブカードコンポーネント
+ */
+export default function SubCard({ index, item }: Props) {
+  const { subImageFile, subDescription } = useContext(SubCardContext);
+
+  /**
+   * サブ画像の説明の変更ハンドラー
+   * @param {number} num - サブ画像のインデックス
+   * @param {string} subDescriptions - サブ画像の説明
+   */
+  const handleAddSubDescription = (num: number, subDescriptions: string) => {};
+
+  return (
+    <CardBody>
+      <Box>
+        <Box display={{ md: 'flex' }}>
+          <Text fontWeight='bold'>ファイル名:&ensp;</Text>
+          <Text mb='3'>{subImageFile.length > 0 ? subImageFile[index].name : '未選択'}</Text>
+        </Box>
+        <Box mb='3'>
+          <Image
+            src={URL.createObjectURL(item)}
+            alt={`plant/sub/${String(subImageFile[0].name)}`}
+            m='0 auto'
+            w='300px'
+          />
+        </Box>
+        <Text fontWeight='bold'>画像説明:</Text>
+        <Textarea
+          placeholder='画像の説明を入力'
+          value={subDescription[0] || ''}
+          onChange={(event) => handleAddSubDescription(0, event.target.value)}
+          borderColor='gray.600'
+          borderRadius='md'
+          px={3}
+          py={2}
+        />
+      </Box>
+    </CardBody>
+  );
+}


### PR DESCRIPTION
# カード表示箇所をコンポーネント化して管理
[issue9](https://github.com/YU01BLC/plant-eatery/issues/9) 対応

## 変更点

- src/components/adminParts/mainCard.tsx
- src/components/adminParts/subCard.tsx
  - `admin.tsx`に記述していたカード表示箇所をmainとsubに切り分けてそれぞれコンポーネントとして管理するよう実装致しました。

- src/page/admin.tsx
  - 認証画面以外の表示を別コンポーネントとしてimportするよう更新致しました。

## 確認事項
以下チェックボックスに全てチェックがついた状態でマージを行うこと。
- [x] コンソール/ターミナルにエラーが出ていないこと
- [x] devTool/simulator等を使用して画面サイズ変更時の見た目を確認していること
- [x] 変更内容を全てPRに記載していること
- [x] 後続作業に影響する内容についてはPRに明記していること

## その他
- それぞれのコンポーネントのinput箇所のイベントは設定していません。
  - 現状文字を入力してもchangeイベントが発火せず、valueが更新されないようになっているため入力が反映されません。
  - イベントの設定については本PRではスコープ外のため、別issueを切って対応する予定です。
